### PR TITLE
Create LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2024 Rulin Shao
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Thank you for your work, it's very fascinating and seems quite valuable for developers, users, and compute efficiencies.

Researching the project I am unable to find an Open Source license file on the work. This happens to people I hear from all the time—busy with a new repo, it's easy to forget to add the license file.

Since I was going to file an Issue suggesting it, I decided to take the next step and hope this makes things easier for you.

I figured MIT is the choice considering the related datastore is MIT licensed. Was this a correct assumption?

The copyright year and name I guessed from the repo name and arXiv paper, but you can always edit the commit to fix or add anything. Maintainers of this repository should be able to commit to this pull request to make any changes before merging, if you wish. You can also leave a comment asking me to change anything in my own pull request, if that's better for you.

Hope this helps!